### PR TITLE
Add mobile webapp capabilities

### DIFF
--- a/template/header.tpl
+++ b/template/header.tpl
@@ -4,6 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset={$CONTENT_ENCODING}">
     <meta name="generator" content="Piwigo (aka PWG), see piwigo.org">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -23,6 +24,8 @@
 
     <title>{if $PAGE_TITLE!=l10n('Home') && $PAGE_TITLE!=$GALLERY_TITLE}{$PAGE_TITLE} | {/if}{$GALLERY_TITLE}</title>
     <link rel="shortcut icon" type="image/x-icon" href="{$ROOT_URL}{$themeconf.icon_dir}/favicon.ico">
+    <link rel="icon" sizes="192x192" href="{$ROOT_URL}themes/bootstrapdefault/img/logo.png">
+    <link rel="apple-touch-icon" sizes="192x192" href="{$ROOT_URL}themes/bootstrapdefault/img/logo.png">
     <link rel="start" title="{'Home'|@translate}" href="{$U_HOME}" >
     <link rel="search" title="{'Search'|@translate}" href="{$ROOT_URL}search.php">
 {if isset($first.U_IMG)   }


### PR DESCRIPTION
Adds support for webapp capabilities for Chrome and I believe also Safari on iOS (sorry don't have a device so I can't actually test it, but it should work).

Depends on Philio/bootstrapdefault#37 (because of logo.png)

Signed-off-by: Daniele Ricci <daniele.athome@gmail.com>