### PR TITLE
Login: Remove max length of passwords

### DIFF
--- a/template/identification.tpl
+++ b/template/identification.tpl
@@ -23,13 +23,13 @@
                 <div class="form-group">
                     <label for="username" class="col-sm-2 control-label">{'Username'|@translate}</label>
                     <div class="col-sm-4">
-                        <input tabindex="1" class="form-control" type="text" name="username" id="username" maxlength="40" placeholder="{'Username'|@translate}">
+                        <input tabindex="1" class="form-control" type="text" name="username" id="username" placeholder="{'Username'|@translate}">
                     </div>
                 </div>
                 <div class="form-group">
                     <label for="password" class="col-sm-2 control-label">{'Password'|@translate}</label>
                     <div class="col-sm-4">
-                        <input tabindex="2" class="form-control" type="password" name="password" id="password" maxlength="25" placeholder="{'Password'|@translate}">
+                        <input tabindex="2" class="form-control" type="password" name="password" id="password" placeholder="{'Password'|@translate}">
                     </div>
                 </div>
 {if $authorize_remembering }


### PR DESCRIPTION
The length of the password should not be restricted by the template, especially regarding the fact that longer passwords are allowed when logging in from the toolbar at the top.