### PR TITLE
Add config to use description rather than title for image caption

### DIFF
--- a/admin/template/settings.tpl
+++ b/admin/template/settings.tpl
@@ -186,6 +186,13 @@
                     </label>
                 </li>
                 <li>
+                    <label class="font-checkbox">
+                        <span class="icon-check"></span>
+                        <input type="checkbox" name="thumbnail_desc"{if $theme_config->thumbnail_desc} checked="checked"{/if}>
+                        {'Use description rather than title for images'|@translate}
+                    </label>
+                </li>
+                <li>
                     <label labelfor="thumbnail_linkto">{'Link thumbnail to'|@translate}</label>
                     <select name="thumbnail_linkto">
                         <option value="picture"{if $theme_config->thumbnail_linkto == 'picture'} selected="selected"{/if}>{'Picture details page'|@translate}</option>

--- a/include/config.php
+++ b/include/config.php
@@ -37,6 +37,7 @@ class Config {
     const KEY_PHOTOSWIPE_METADATA = 'photoswipe_metadata';
     const KEY_THUMBNAIL_LINKTO = 'thumbnail_linkto';
     const KEY_THUMBNAIL_CAPTION = 'thumbnail_caption';
+    const KEY_THUMBNAIL_DESC = 'thumbnail_desc';
     const KEY_THUMBNAIL_CAT_DESC = 'thumbnail_cat_desc';
     const KEY_CATEGORY_WELLS = 'category_wells';
     const KEY_LOGO_IMAGE_ENABLED = 'logo_image_enabled';
@@ -83,6 +84,7 @@ class Config {
         self::KEY_PHOTOSWIPE_METADATA => false,
         self::KEY_THUMBNAIL_LINKTO => 'picture',
         self::KEY_THUMBNAIL_CAPTION => true,
+        self::KEY_THUMBNAIL_DESC => false,
         self::KEY_THUMBNAIL_CAT_DESC => 'simple',
         self::KEY_CATEGORY_WELLS => 'never',
         self::KEY_LOGO_IMAGE_ENABLED => false,
@@ -127,6 +129,7 @@ class Config {
         self::KEY_PHOTOSWIPE_METADATA => self::TYPE_BOOL,
         self::KEY_THUMBNAIL_LINKTO => self::TYPE_STRING,
         self::KEY_THUMBNAIL_CAPTION => self::TYPE_BOOL,
+        self::KEY_THUMBNAIL_DESC => self::TYPE_BOOL,
         self::KEY_THUMBNAIL_CAT_DESC => self::TYPE_STRING,
         self::KEY_CATEGORY_WELLS => self::TYPE_STRING,
         self::KEY_LOGO_IMAGE_ENABLED => self::TYPE_BOOL,

--- a/language/en_UK/theme.lang.php
+++ b/language/en_UK/theme.lang.php
@@ -38,6 +38,7 @@ $lang['Show basic EXIF metadata'] = 'Show basic EXIF metadata';
 $lang['For more information on metadata visit'] = 'For more information on metadata visit';
 $lang['Thumbnail page display'] = 'Thumbnail page display';
 $lang['Show image caption'] = 'Show image caption';
+$lang['Use description rather than title for images'] = 'Use description rather than title for images';
 $lang['from'] = 'from';
 $lang['Site logo'] = 'Site logo';
 $lang['Display a site logo image instead of plain text'] = 'Display a site logo image instead of plain text';

--- a/template/thumbnails.tpl
+++ b/template/thumbnails.tpl
@@ -35,7 +35,19 @@
 {if $SHOW_THUMBNAIL_CAPTION}
         <div class="card-body{if !$theme_config->thumbnail_caption && $smarty.cookies.view != 'list'} d-none{/if}{if !$theme_config->thumbnail_caption} list-view-only{/if}">
             <h6 class="card-title">
+{if $theme_config->thumbnail_desc}
+            {if !empty($thumbnail.DESCRIPTION)}
+                <div id="content-description" class="py-3{if $theme_config->thumbnail_cat_desc == 'simple'} text-center{/if}">
+            {if $theme_config->thumbnail_cat_desc == 'simple'}
+                    <h5>{$thumbnail.DESCRIPTION}</h5>
+            {else}
+                    {$thumbnail.DESCRIPTION}
+            {/if}
+                </div>
+            {/if}
+{else}
                 <a href="{$thumbnail.URL}" class="ellipsis{if !empty($thumbnail.icon_ts)} recent{/if}">{$thumbnail.NAME}</a>
+{/if}
 {if !empty($thumbnail.icon_ts)}
                 <img title="{$thumbnail.icon_ts.TITLE}" src="{$ROOT_URL}{$themeconf.icon_dir}/recent.png" alt="(!)">
 {/if}


### PR DESCRIPTION
This PR adds a new boolean (checkbox) configuration item that controls how the image caption is constructed.  The default is to use the image title, which matches the existing behavior.  By checking the checkbox, the image description is used instead of the title.  A side effect is that images with no description have no captions.

Thanks for considering this change.   Let me know if you have any questions about what I'm trying to accomplish, or if you would prefer to see this accomplished in a different way.

