### PR TITLE
fixes #230 load (again) the local language file, if any

### DIFF
--- a/include/themecontroller.php
+++ b/include/themecontroller.php
@@ -10,6 +10,7 @@ class ThemeController {
 
     public function init() {
         load_language('theme.lang', PHPWG_THEMES_PATH.'bootstrap_darkroom/');
+        load_language('lang', PHPWG_ROOT_PATH.PWG_LOCAL_DIR, array('no_fallback'=>true, 'local'=>true) );
 
         add_event_handler('init', array($this, 'assignConfig'));
         add_event_handler('init', array($this, 'setInitValues'));


### PR DESCRIPTION
Unfortunately with themes, we can't use the `loading_lang` trigger (which would make the reload of the local language file totally useless), so reloading is the best/simplest option here.