### PR TITLE
fullscreen bars as overlay on desktop browsers.

### DIFF
--- a/template/_photoswipe_js.tpl
+++ b/template/_photoswipe_js.tpl
@@ -119,6 +119,7 @@ function startPhotoSwipe(idx) {
             closeOnVerticalDrag: false,
             focus: false,
             history: $history,
+            {literal}barsSize: {top:0, bottom:0},{/literal}
             preload: [1,2],
 {if $theme_config->social_enabled}
             shareButtons: [


### PR DESCRIPTION
On desktop browsers the bars in fullscreen mode (caption at the bottom and buttons at the top) are not shown as overlays at the moment. For this reason images are not shown edge to edge of the screen. Images are smaller with black bars on top and bottom

In my opinion you get a better viewing experience when the images take up the whole screen.  
See screenshot examples in my issue https://github.com/tkuther/piwigo-bootstrap-darkroom/issues/252.

This can be achieved when setting the barsSize for top and bottom to zero.  
I had to add the line between a`{literal}` block because of the curly braces of the barsSize property.