### PR TITLE
fixes #265 additional check for Download by Size activity

### DIFF
--- a/template/_plugin_fixes_js.tpl
+++ b/template/_plugin_fixes_js.tpl
@@ -120,6 +120,10 @@ $(window).on('load', function() {
 {if isset($loaded_plugins['download_by_size'])}
 {footer_script require='jquery'}
 $(document).ready(function() {
+  if ($('#downloadSizeBox').length < 1) {
+    return false;
+  }
+
   var liDownloadSizeLink = $('#downloadSwitchLink').closest('li');
   $(liDownloadSizeLink).addClass('dropdown');
   $('#downloadSizeBox').appendTo(liDownloadSizeLink);


### PR DESCRIPTION
It is not because Download by Size is active that it offers a list of sizes to download. For a PDF file, Download by Size will have no effect. Thus Bootstrap Darkroom should not transform a button into a dropdown.