### PR TITLE
Allow direct-linking of PhotoSwipe images

### DIFF
--- a/template/index.tpl
+++ b/template/index.tpl
@@ -249,6 +249,13 @@ function setupPhotoSwipe() {
          });
       }
    });
+
+   if (window.location.hash) {
+        const pidMatch = /(#|&)pid=(\d+)(&|$)/.exec(window.location.hash);
+        if (pidMatch) {
+            startPhotoSwipe(parseInt(pidMatch[2]) - 1);
+        }
+   }
 }
 
 {if $theme_config->thumbnail_linkto == 'photoswipe' || ($theme_config->thumbnail_linkto == 'photoswipe_mobile_only' && get_device() != 'desktop')}


### PR DESCRIPTION
When PhotoSwipe is enabled as "detailed view" and a user browses through
the gallery, the current image is always reflected in the url in the
form of "#&gid=x&pid=y". When a link is opened already containing this
info (i.e. a direct link to an image in the gallery) we now parse the
pid out of this querystring-like string and pass it to
startPhotoSwipe(). As pid is 1-based and startPhotoSwipe()'s index is
0-based we need to substract one from the given pid.

Fixes #318